### PR TITLE
Py3pep

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,12 +18,12 @@ src = ["liborigin.pyx", "OriginObj.cpp",
        "Origin610Parser.cpp", "Origin810Parser.cpp",
        "Origin700Parser.cpp", "OriginDefaultParser.cpp"]
 surf3d_ext = Extension("liborigin", src, language='c++')
-#surf3d_ext = cythonize("liborigin.pyx", sources=src, language="c++")
+# surf3d_ext = cythonize("liborigin.pyx", sources=src, language="c++")
 
 # finally, we can pass all this to distutils
 extensions = [surf3d_ext]
 setup(
     name="liborigin",
     ext_modules=extensions,
-    cmdclass = {'build_ext': build_ext},
+    cmdclass={'build_ext': build_ext},
 )

--- a/setup.py
+++ b/setup.py
@@ -7,8 +7,8 @@ try:
     from Cython.Distutils import build_ext
     from Cython.Build import cythonize
 except:
-    print "You don't seem to have Cython installed. Please get a"
-    print "copy from http://cython.org and install it"
+    print("You don't seem to have Cython installed. Please get a")
+    print("copy from http://cython.org and install it")
     sys.exit(1)
 
 


### PR DESCRIPTION
use `print()` to be compatible with python3 and small PEP8 tweaks